### PR TITLE
Simplify code to make it easier to deal with imports

### DIFF
--- a/bos/abi/core.go
+++ b/bos/abi/core.go
@@ -47,6 +47,10 @@ func ReadAndDecodeContractReturn(abiLocation, funcName string, resultRaw []byte,
 func Packer(abiData, funcName string, args ...string) ([]byte, error) {
 	abiSpec, err := ReadAbiSpec([]byte(abiData))
 	if err != nil {
+		log.WithFields(log.Fields{
+			"abi":   abiData,
+			"error": err.Error(),
+		}).Error("Failed to decode abi spec")
 		return nil, err
 	}
 
@@ -56,6 +60,10 @@ func Packer(abiData, funcName string, args ...string) ([]byte, error) {
 	}
 	packedBytes, err := abiSpec.Pack(funcName, iArgs...)
 	if err != nil {
+		log.WithFields(log.Fields{
+			"abi":   abiData,
+			"error": err.Error(),
+		}).Error("Failed to encode abi spec")
 		return nil, err
 	}
 

--- a/bos/compile/perform_compilation.go
+++ b/bos/compile/perform_compilation.go
@@ -135,7 +135,6 @@ func RequestBinaryLinkage(file string, libraries map[string]string) (*BinaryResp
 	}, nil
 }
 
-//todo: Might also need to add in a map of library names to addrs
 func RequestCompile(file string, optimize bool, libraries map[string]string) (*Response, error) {
 	input := SolidityInput{Language: "Solidity", Sources: make(map[string]SolidityInputSource)}
 

--- a/bos/def/job.go
+++ b/bos/def/job.go
@@ -30,6 +30,8 @@ type Job struct {
 	UpdateAccount *UpdateAccount `mapstructure:"update-account,omitempty" json:"update-account,omitempty" yaml:"update-account,omitempty" toml:"update-account"`
 	// Contract compile and send to the chain functions
 	Deploy *Deploy `mapstructure:"deploy,omitempty" json:"deploy,omitempty" yaml:"deploy,omitempty" toml:"deploy"`
+	// Contract compile/build
+	Build *Build `mapstructure:"build,omitempty" json:"build,omitempty" yaml:"build,omitempty" toml:"build"`
 	// Send tokens from one account to another
 	Send *Send `mapstructure:"send,omitempty" json:"send,omitempty" yaml:"send,omitempty" toml:"send"`
 	// Utilize monax:db's native name registry to register a name

--- a/bos/def/jobs.go
+++ b/bos/def/jobs.go
@@ -210,6 +210,21 @@ type Variable struct {
 	Value string
 }
 
+type Build struct {
+	// (Required) the filepath to the contract file. this should be relative to the current path **or**
+	// relative to the contracts path established via the --contracts-path flag or the $EPM_CONTRACTS_PATH
+	// environment variable. If contract has a "bin" file extension then it will not be sent to the
+	// compilers but rather will just be sent to the chain. Note, if you use a "call" job after deploying
+	// a binary contract then you will be **required** to utilize an abi field in the call job.
+	Contract string `mapstructure:"contract" json:"contract" yaml:"contract" toml:"contract"`
+}
+
+func (job *Build) Validate() error {
+	return validation.ValidateStruct(job,
+		validation.Field(&job.Contract, validation.Required),
+	)
+}
+
 type Deploy struct {
 	// (Optional, if account job or global account set) address of the account from which to send (the
 	// public key for the account must be available to burrow keys)

--- a/bos/jobs/job_manager.go
+++ b/bos/jobs/job_manager.go
@@ -84,6 +84,9 @@ func RunJobs(do *def.Packages) error {
 		case *def.Call:
 			announce(job.Name, "Call")
 			job.Result, job.Variables, err = CallJob(job.Call, do)
+		case *def.Build:
+			announce(job.Name, "Build")
+			job.Result, err = BuildJob(job.Build, do)
 
 		// State jobs
 		case *def.RestoreState:

--- a/bos/jobs/jobs_contracts.go
+++ b/bos/jobs/jobs_contracts.go
@@ -215,23 +215,15 @@ func matchInstanceName(objectName, deployInstance string) bool {
 }
 
 func findContractFile(contract, binPath string) (string, error) {
-	var contractPath string
-	if _, err := os.Stat(contract); err != nil {
-		if _, secErr := os.Stat(filepath.Join(binPath, contract)); secErr != nil {
-			if _, thirdErr := os.Stat(filepath.Join(binPath, filepath.Base(contract))); thirdErr != nil {
-				return "", fmt.Errorf("Could not find contract in\n* primary path: %v\n* binary path: %v\n* tertiary path: %v",
-					contract, filepath.Join(binPath, contract), filepath.Join(binPath, filepath.Base(contract)))
-			} else {
-				contractPath = filepath.Join(binPath, filepath.Base(contract))
-			}
-		} else {
-			contractPath = filepath.Join(binPath, contract)
+	contractPaths := []string{contract, filepath.Join(binPath, contract), filepath.Join(binPath, filepath.Base(contract))}
+
+	for _, p := range contractPaths {
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
 		}
-	} else {
-		contractPath = contract
 	}
 
-	return contractPath, nil
+	return "", fmt.Errorf("Could not find contract in any of %v", contractPaths)
 }
 
 // TODO [rj] refactor to remove [contractPath] from functions signature => only used in a single error throw.

--- a/tests/jobs_fixtures/app16-binding_abi_using_address_returns_factory_and_base_separate/epm.yaml
+++ b/tests/jobs_fixtures/app16-binding_abi_using_address_returns_factory_and_base_separate/epm.yaml
@@ -11,7 +11,7 @@ jobs:
 
 - name: deployGSABIFactory
   deploy:
-      contract: GSFactory.sol
+      contract: GSContract.sol
       instance: GSContract
 
 - name: createGSContract

--- a/tests/jobs_fixtures/app24-multiple_inheritance_and_intermingling_contracts/epm.yaml
+++ b/tests/jobs_fixtures/app24-multiple_inheritance_and_intermingling_contracts/epm.yaml
@@ -3,7 +3,7 @@ jobs:
   #deploy contract One
 - name: deployOne 
   deploy:
-       contract: three.sol
+       contract: one.sol
        instance: one
  
 - name: get1i 
@@ -21,7 +21,7 @@ jobs:
 #deploy contract two
 - name: deployTwo 
   deploy:
-       contract: three.sol
+       contract: two.sol
        instance: two
  
 - name:  get2i 

--- a/tests/jobs_fixtures/app26-factories_single_constructor_and_overwriting_testing/epm.yaml
+++ b/tests/jobs_fixtures/app26-factories_single_constructor_and_overwriting_testing/epm.yaml
@@ -15,7 +15,7 @@ jobs:
 
 - name: deployGSABIFactory
   deploy:
-      contract: GSFactory.sol
+      contract: GSContract.sol
       instance: GSContract
 
 - name: createGSContract

--- a/tests/jobs_fixtures/app27-multiple_imports_and_multiple_constructor_different_factory_types/epm.yaml
+++ b/tests/jobs_fixtures/app27-multiple_imports_and_multiple_constructor_different_factory_types/epm.yaml
@@ -16,7 +16,7 @@ jobs:
 # Begin with single constructor contract
 - name: deployGSABIFactorySingle
   deploy:
-      contract: contracts/GSFactory.sol
+      contract: contracts/GSSingle.sol
       instance: GSSingle
 
 - name: createGSContractSingle
@@ -77,7 +77,7 @@ jobs:
 # Now Multi constructor Contract
 - name: deployGSABIFactoryMulti
   deploy:
-      contract: contracts/GSFactory.sol
+      contract: contracts/GSMulti.sol
       instance: GSMulti
 
 - name: createGSContractMulti


### PR DESCRIPTION
By passing in the path of the solidity file, imports are handled correctly
for free. Requires blackstone changes.

Bunch of cleanups and fixes needed for blackstone

Signed-off-by: Sean Young <sean.young@monax.io>