### PR TITLE
Block & Tx tables to store raw data, delete events based on identifier

### DIFF
--- a/vent/README.md
+++ b/vent/README.md
@@ -15,6 +15,7 @@ Given a sqlsol specification
   {
     "TableName" : "EventTest",
     "Filter" : "Log1Text = 'LOGEVENT1'",
+    "DeleteFilter": "CRUD_ACTION = 'delete'",
     "Columns"  : {
       "key" : {"name" : "testname", "type": "bytes32", "primary" : true},
       "description": {"name" : "testdescription", "type": "bytes32", "primary" : false, "bytesToString": true}
@@ -81,25 +82,26 @@ go install ./vent
 # Print command help:
 vent --help
 
-# Run vent command with postgres adapter, spec & abi files path:
-vent --db-adapter="postgres" --db-url="postgres://user:pass@localhost:5432/vent?sslmode=disable" --db-schema="vent" --grpc-addr="localhost:10997" --http-addr="0.0.0.0:8080" --log-level="debug" --spec-file="<sqlsol specification file path>" --abi-file="<abi file path>"
+# Run vent command with postgres adapter, spec & abi files path, also stores block & tx data:
+vent --db-adapter="postgres" --db-url="postgres://user:pass@localhost:5432/vent?sslmode=disable" --db-schema="vent" --grpc-addr="localhost:10997" --http-addr="0.0.0.0:8080" --log-level="debug" --spec-file="<sqlsol specification file path>" --abi-file="<abi file path>" --db-block=true
 
-# Run vent command with sqlite adapter, spec & abi directories path:
+# Run vent command with sqlite adapter, spec & abi directories path, does not store block & tx data:
 vent --db-adapter="sqlite" --db-url="./vent.sqlite" --grpc-addr="localhost:10997" --http-addr="0.0.0.0:8080" --log-level="debug" --spec-dir="<sqlsol specification directory path>" --abi-dir="<abi files directory path>"
 ```
 
 Configuration Flags:
 
-+ `db-adapter`: Database adapter, 'postgres' or 'sqlite' are fully supported
-+ `db-url`: PostgreSQL database URL or SQLite db file path
-+ `db-schema`: PostgreSQL database schema or empty for SQLite
-+ `http-addr`: Address to bind the HTTP server
-+ `grpc-addr`: Address to listen to gRPC Hyperledger Burrow server
-+ `log-level`: Logging level (error, warn, info, debug)
-+ `spec-file`: SQLSol specification json file (full path)
-+ `spec-dir`: Path of a folder to look for SQLSol json specification files
-+ `abi-file`: Event Abi specification file full path
-+ `abi-dir`: Path of a folder to look for event Abi specification files
++ `db-adapter`: (string) Database adapter, 'postgres' or 'sqlite' are fully supported
++ `db-url`: (string) PostgreSQL database URL or SQLite db file path
++ `db-schema`: (string) PostgreSQL database schema or empty for SQLite
++ `http-addr`: (string) Address to bind the HTTP server
++ `grpc-addr`: (string) Address to listen to gRPC Hyperledger Burrow server
++ `log-level`: (string) Logging level (error, warn, info, debug)
++ `spec-file`: (string) SQLSol specification json file (full path)
++ `spec-dir`: (string) Path of a folder to look for SQLSol json specification files
++ `abi-file`: (string) Event Abi specification file full path
++ `abi-dir`: (string) Path of a folder to look for event Abi specification files
++ `db-block`: (boolean) Create block & transaction tables and persist related data (true/false)
 
 
 NOTES:
@@ -109,5 +111,7 @@ If `spec-dir` is given, vent will search for all `.json` spec files in given dir
 
 Also one of `abi-file` or `abi-dir` must be provided.
 If `abi-dir` is given, vent will search for all `.abi` spec files in given directory.
+
+if `db-block` is set to true (block explorer mode), Block and Transaction tables are created in addition to log and event tables to store block & tx raw info.
 
 It can be checked that vent is connected and ready sending a request to `http://<http-addr>/health` which will return a `200` OK response in case everything's fine.

--- a/vent/cmd/vent.go
+++ b/vent/cmd/vent.go
@@ -33,6 +33,7 @@ func init() {
 	ventCmd.Flags().StringVar(&cfg.AbiFile, "abi-file", cfg.AbiFile, "Event Abi specification file full path")
 	ventCmd.Flags().StringVar(&cfg.AbiDir, "abi-dir", cfg.AbiDir, "Path of a folder to look for event Abi specification files")
 	ventCmd.Flags().StringVar(&cfg.SpecDir, "spec-dir", cfg.SpecDir, "Path of a folder to look for SQLSol json specification files")
+	ventCmd.Flags().BoolVar(&cfg.DBBlockTx, "db-block", cfg.DBBlockTx, "Create block & transaction tables and persist related data (true/false)")
 }
 
 // Execute executes the vent command
@@ -47,12 +48,12 @@ func runVentCmd(cmd *cobra.Command, args []string) {
 	consumer := service.NewConsumer(cfg, log, make(chan types.EventData))
 	server := service.NewServer(cfg, log, consumer)
 
-	parser, err := sqlsol.SpecLoader(cfg.SpecFile, cfg.SpecDir)
+	parser, err := sqlsol.SpecLoader(cfg.SpecDir, cfg.SpecFile, cfg.DBBlockTx)
 	if err != nil {
 		log.Error("err", err)
 		os.Exit(1)
 	}
-	abiSpec, err := sqlsol.AbiLoader(cfg.AbiFile, cfg.AbiDir)
+	abiSpec, err := sqlsol.AbiLoader(cfg.AbiDir, cfg.AbiFile)
 	if err != nil {
 		log.Error("err", err)
 		os.Exit(1)

--- a/vent/cmd/vent.go
+++ b/vent/cmd/vent.go
@@ -47,7 +47,7 @@ func runVentCmd(cmd *cobra.Command, args []string) {
 	log := logger.NewLogger(cfg.LogLevel)
 	consumer := service.NewConsumer(cfg, log, make(chan types.EventData))
 	server := service.NewServer(cfg, log, consumer)
-  
+
 	parser, err := sqlsol.SpecLoader(cfg.SpecDir, cfg.SpecFile, cfg.DBBlockTx)
 	if err != nil {
 		log.Error("err", err)

--- a/vent/config/config.go
+++ b/vent/config/config.go
@@ -16,6 +16,7 @@ type Flags struct {
 	SpecDir   string
 	AbiFile   string
 	AbiDir    string
+	DBBlockTx bool
 }
 
 // DefaultFlags returns a configuration with default values
@@ -31,5 +32,6 @@ func DefaultFlags() *Flags {
 		SpecDir:   "",
 		AbiFile:   "",
 		AbiDir:    "",
+		DBBlockTx: false,
 	}
 }

--- a/vent/service/consumer.go
+++ b/vent/service/consumer.go
@@ -236,10 +236,12 @@ func (c *Consumer) Run(parser *sqlsol.Parser, abiSpec *abi.AbiSpec, stream bool)
 							if spec.DeleteFilter != "" {
 								deleteFilter = strings.Split(replacer.Replace(spec.DeleteFilter), "=")
 							}
+							deleteFilterLength := len(deleteFilter)
+
 							// for each data element, maps to SQL columnName and gets its value
 							// if there is no matching column for the item, it doesn't need to be stored in db
 							for k, v := range eventData {
-								if len(deleteFilter) > 0 {
+								if deleteFilterLength > 0 {
 									if k == deleteFilter[0] {
 										if bytes, ok := v.(*[]byte); ok {
 											str := strings.Trim(string(*bytes), "\x00")

--- a/vent/service/server_test.go
+++ b/vent/service/server_test.go
@@ -36,8 +36,8 @@ func TestServer(t *testing.T) {
 	log := logger.NewLogger(cfg.LogLevel)
 	consumer := service.NewConsumer(cfg, log, make(chan types.EventData))
 
-	parser, err := sqlsol.SpecLoader(cfg.SpecFile, "")
-	abiSpec, err := sqlsol.AbiLoader(cfg.AbiFile, "")
+	parser, err := sqlsol.SpecLoader("", cfg.SpecFile, false)
+	abiSpec, err := sqlsol.AbiLoader("", cfg.AbiFile)
 
 	var wg sync.WaitGroup
 

--- a/vent/sqldb/adapters/db_adapter.go
+++ b/vent/sqldb/adapters/db_adapter.go
@@ -34,4 +34,6 @@ type DBAdapter interface {
 	InsertLogQuery() string
 	// UpsertQuery builds an INSERT... ON CONFLICT (or similar) query to upsert data in event tables based on PK
 	UpsertQuery(table types.SQLTable, row types.EventDataRow) (string, string, []interface{}, error)
+	//DeleteQuery builds a DELETE FROM event tables query based on PK
+	DeleteQuery(table types.SQLTable, row types.EventDataRow) (string, string, []interface{}, error)
 }

--- a/vent/sqldb/sqldb.go
+++ b/vent/sqldb/sqldb.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"strings"
+
 	"github.com/monax/bosmarmot/vent/logger"
 	"github.com/monax/bosmarmot/vent/sqldb/adapters"
 	"github.com/monax/bosmarmot/vent/types"
@@ -50,22 +52,22 @@ func NewSQLDB(dbAdapter, dbURL, schema string, log *logger.Logger) (*SQLDB, erro
 	}
 
 	db.Log.Info("msg", "Initializing DB")
-	eventTables := db.getSysTablesDefinition()
+
+	// create dictionary and log tables
+	sysTables := db.getSysTablesDefinition()
 
 	// IMPORTANT: DO NOT CHANGE TABLE CREATION ORDER (1)
-	table := eventTables[types.SQLDictionaryTableName]
-	if err = db.createTable(table); err != nil {
+	if err = db.createTable(sysTables[types.SQLDictionaryTableName]); err != nil {
 		if !db.DBAdapter.ErrorEquals(err, types.SQLErrorTypeDuplicatedTable) {
-			db.Log.Debug("msg", "Error Initializing DB", "err", err)
+			db.Log.Debug("msg", "Error creating Dictionary table", "err", err)
 			return nil, err
 		}
 	}
 
 	// IMPORTANT: DO NOT CHANGE TABLE CREATION ORDER (2)
-	table = eventTables[types.SQLLogTableName]
-	if err = db.createTable(table); err != nil {
+	if err = db.createTable(sysTables[types.SQLLogTableName]); err != nil {
 		if !db.DBAdapter.ErrorEquals(err, types.SQLErrorTypeDuplicatedTable) {
-			db.Log.Debug("msg", "Error Initializing DB", "err", err)
+			db.Log.Debug("msg", "Error creating Log table", "err", err)
 			return nil, err
 		}
 	}
@@ -130,7 +132,7 @@ func (db *SQLDB) SynchronizeDB(eventTables types.EventTables) error {
 
 // SetBlock inserts or updates multiple rows and stores log info in SQL tables
 func (db *SQLDB) SetBlock(eventTables types.EventTables, eventData types.EventData) error {
-	db.Log.Debug("msg", "Set Block..........")
+	db.Log.Debug("msg", "Sinchronize Block..........")
 
 	var safeTable string
 	var logStmt *sql.Stmt
@@ -169,19 +171,45 @@ loop:
 
 		// for Each Row
 		for _, row := range dataRows {
-			query, values, pointers, errQuery := db.DBAdapter.UpsertQuery(table, row)
-			query = clean(query)
 
-			if errQuery != nil {
-				db.Log.Debug("msg", "Error building query", "err", errQuery, "value", fmt.Sprintf("%v %v", table, row))
-				return err
+			var query string
+			var values string
+			var pointers []interface{}
+			var errQuery error
+			var action string
+
+			switch row.Action {
+			case types.ActionUpsert:
+				//prepare upsert
+				query, values, pointers, errQuery = db.DBAdapter.UpsertQuery(table, row)
+				if errQuery != nil {
+					db.Log.Debug("msg", "Error building upsert query", "err", errQuery, "value", fmt.Sprintf("%v %v", table, row))
+					return err
+				}
+				action = "UPSERT"
+
+			case types.ActionDelete:
+				//prepare delete
+				query, values, pointers, errQuery = db.DBAdapter.DeleteQuery(table, row)
+				if errQuery != nil {
+					db.Log.Debug("msg", "Error building delete query", "err", errQuery, "value", fmt.Sprintf("%v %v", table, row))
+					return err
+				}
+				action = "DELETE"
+
+			default:
+				//invalid action
+				db.Log.Debug("msg", "Error building query", "value", fmt.Sprintf("%d", row.Action))
+				return fmt.Errorf("invalid row action %d", row.Action)
 			}
 
+			query = clean(query)
+
 			// upsert row data
-			db.Log.Debug("msg", "UPSERT", "query", query, "value", values)
+			db.Log.Debug("msg", action, "query", query, "value", values)
 			_, err = tx.Exec(query, pointers...)
 			if err != nil {
-				db.Log.Debug("msg", "Error upserting row", "err", err, "value", values)
+				db.Log.Debug("msg", "Error "+strings.ToLower(action)+"ing row", "err", err, "value", values)
 				// exits from all loops -> continue in close log stmt
 				break loop
 			}
@@ -237,14 +265,14 @@ loop:
 	return nil
 }
 
-// GetBlock returns all tables structures and row data for given block & events filter
-func (db *SQLDB) GetBlock(eventFilter, block string) (types.EventData, error) {
+// GetBlock returns all tables structures and row data for given block
+func (db *SQLDB) GetBlock(block string) (types.EventData, error) {
 	var data types.EventData
 	data.Block = block
 	data.Tables = make(map[string]types.EventDataTable)
 
 	// get all table structures involved in the block
-	tables, err := db.getBlockTables(eventFilter, block)
+	tables, err := db.getBlockTables(block)
 	if err != nil {
 		return data, err
 	}
@@ -288,6 +316,7 @@ func (db *SQLDB) GetBlock(eventFilter, block string) (types.EventData, error) {
 
 		for rows.Next() {
 			row := make(map[string]interface{})
+			//var row types.EventDataRow
 
 			if err = rows.Scan(pointers...); err != nil {
 				db.Log.Debug("msg", "Error scanning data", "err", err)
@@ -303,7 +332,7 @@ func (db *SQLDB) GetBlock(eventFilter, block string) (types.EventData, error) {
 				}
 			}
 
-			dataRows = append(dataRows, row)
+			dataRows = append(dataRows, types.EventDataRow{Action: types.ActionRead, RowData: row})
 		}
 
 		if err = rows.Err(); err != nil {

--- a/vent/sqldb/sqldb.go
+++ b/vent/sqldb/sqldb.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-
 	"strings"
 
 	"github.com/monax/bosmarmot/vent/logger"

--- a/vent/sqldb/sqldb_test.go
+++ b/vent/sqldb/sqldb_test.go
@@ -62,7 +62,7 @@ func TestSetBlock(t *testing.T) {
 		_, err = db.GetLastBlockID()
 		require.NoError(t, err)
 
-		_, err = db.GetBlock("TEST", dat.Block)
+		_, err = db.GetBlock(dat.Block)
 		require.NoError(t, err)
 
 		// alter
@@ -87,7 +87,7 @@ func TestSetBlock(t *testing.T) {
 		_, err = db.GetLastBlockID()
 		require.NoError(t, err)
 
-		_, err = db.GetBlock("TEST", dat.Block)
+		_, err = db.GetBlock(dat.Block)
 		require.NoError(t, err)
 
 		// alter
@@ -188,32 +188,34 @@ func getBlock() (types.EventTables, types.EventData) {
 	dat.Tables = make(map[string]types.EventDataTable)
 
 	var rows1 []types.EventDataRow
-	rows1 = append(rows1, map[string]interface{}{"test_id": "1", "col1": "text11", "col2": "text12", "_height": "0123456789ABCDEF0", "col4": "14"})
-	rows1 = append(rows1, map[string]interface{}{"test_id": "2", "col1": "text21", "col2": "text22", "_height": "0123456789ABCDEF0", "col4": "24"})
-	rows1 = append(rows1, map[string]interface{}{"test_id": "3", "col1": "text31", "col2": "text32", "_height": "0123456789ABCDEF0", "col4": "34"})
-	rows1 = append(rows1, map[string]interface{}{"test_id": "4", "col1": "text41", "col3": "text43", "_height": "0123456789ABCDEF0"})
-	rows1 = append(rows1, map[string]interface{}{"test_id": "1", "col1": "upd", "col2": "upd", "_height": "0123456789ABCDEF0", "col4": "upd"})
+	rows1 = append(rows1, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"test_id": "1", "col1": "text11", "col2": "text12", "_height": "0123456789ABCDEF0", "col4": "14"}})
+	rows1 = append(rows1, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"test_id": "2", "col1": "text21", "col2": "text22", "_height": "0123456789ABCDEF0", "col4": "24"}})
+	rows1 = append(rows1, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"test_id": "3", "col1": "text31", "col2": "text32", "_height": "0123456789ABCDEF0", "col4": "34"}})
+	rows1 = append(rows1, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"test_id": "4", "col1": "text41", "col3": "text43", "_height": "0123456789ABCDEF0"}})
+	rows1 = append(rows1, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"test_id": "1", "col1": "upd", "col2": "upd", "_height": "0123456789ABCDEF0", "col4": "upd"}})
 	dat.Tables["test_table1"] = rows1
 
 	var rows2 []types.EventDataRow
-	rows2 = append(rows2, map[string]interface{}{"_height": "0123456789ABCDEF0", "sid_id": "1", "field_1": "A", "field_2": "B"})
-	rows2 = append(rows2, map[string]interface{}{"_height": "0123456789ABCDEF0", "sid_id": "2", "field_1": "C", "field_2": ""})
-	rows2 = append(rows2, map[string]interface{}{"_height": "0123456789ABCDEF0", "sid_id": "3", "field_1": "D", "field_2": "E"})
-	rows2 = append(rows2, map[string]interface{}{"_height": "0123456789ABCDEF0", "sid_id": "1", "field_1": "F"})
-	rows2 = append(rows2, map[string]interface{}{"_height": "0123456789ABCDEF0", "sid_id": "1", "field_2": "U"})
+	rows2 = append(rows2, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "0123456789ABCDEF0", "sid_id": "1", "field_1": "A", "field_2": "B"}})
+	rows2 = append(rows2, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "0123456789ABCDEF0", "sid_id": "2", "field_1": "C", "field_2": ""}})
+	rows2 = append(rows2, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "0123456789ABCDEF0", "sid_id": "3", "field_1": "D", "field_2": "E"}})
+	rows2 = append(rows2, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "0123456789ABCDEF0", "sid_id": "1", "field_1": "F"}})
+	rows2 = append(rows2, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "0123456789ABCDEF0", "sid_id": "1", "field_2": "U"}})
 	dat.Tables["test_table2"] = rows2
 
 	var rows3 []types.EventDataRow
-	rows3 = append(rows3, map[string]interface{}{"_height": "0123456789ABCDEF1", "val": "1"})
-	rows3 = append(rows3, map[string]interface{}{"_height": "0123456789ABCDEF2", "val": "2"})
-	rows3 = append(rows3, map[string]interface{}{"_height": "0123456789ABCDEFX", "val": "-1"})
-	rows3 = append(rows3, map[string]interface{}{"_height": "0123456789ABCDEF0"})
+	rows3 = append(rows3, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "0123456789ABCDEF1", "val": "1"}})
+	rows3 = append(rows3, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "0123456789ABCDEF2", "val": "2"}})
+	rows3 = append(rows3, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "0123456789ABCDEFX", "val": "-1"}})
+	rows3 = append(rows3, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "0123456789ABCDEF0"}})
 	dat.Tables["test_table3"] = rows3
 
 	var rows4 []types.EventDataRow
-	rows4 = append(rows4, map[string]interface{}{"_height": "0123456789ABCDEF0", "time": "2006-01-01 15:04:05", "index": "1"})
-	rows4 = append(rows4, map[string]interface{}{"_height": "0123456789ABCDEF0", "time": "2006-01-02 15:04:05", "index": "2"})
-	rows4 = append(rows4, map[string]interface{}{"_height": "0123456789ABCDEF0", "time": "2006-01-03 15:04:05", "index": "3"})
+	rows4 = append(rows4, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "0123456789ABCDEF0", "time": "2006-01-01 15:04:05", "index": "1"}})
+	rows4 = append(rows4, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "0123456789ABCDEF0", "time": "2006-01-02 15:04:05", "index": "2"}})
+	rows4 = append(rows4, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "0123456789ABCDEF0", "time": "2006-01-03 15:04:05", "index": "3"}})
+	rows4 = append(rows4, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "0123456789ABCDEF0", "time": "2006-01-03 15:04:05", "index": "4"}})
+	rows4 = append(rows4, types.EventDataRow{Action: types.ActionDelete, RowData: map[string]interface{}{"_height": "0123456789ABCDEF0", "time": "2006-01-03 15:04:05", "index": "3"}})
 	dat.Tables["test_table4"] = rows4
 
 	return str, dat
@@ -235,9 +237,9 @@ func getAlterBlock() (types.EventTables, types.EventData) {
 	dat.Block = "AAAAAAAAAAAAAA"
 	dat.Tables = make(map[string]types.EventDataTable)
 
-	var rows4 []types.EventDataRow
-	rows4 = append(rows4, map[string]interface{}{"_height": "AAAAAAAAAAAAAAAAA", "val": "1", "val_alter": "1"})
-	dat.Tables["test_table3"] = rows4
+	var rows5 []types.EventDataRow
+	rows5 = append(rows5, types.EventDataRow{Action: types.ActionUpsert, RowData: map[string]interface{}{"_height": "AAAAAAAAAAAAAAAAA", "val": "1", "val_alter": "1"}})
+	dat.Tables["test_table3"] = rows5
 
 	return str, dat
 }

--- a/vent/sqldb/utils.go
+++ b/vent/sqldb/utils.go
@@ -35,53 +35,53 @@ func (db *SQLDB) getSysTablesDefinition() types.EventTables {
 	logCol := make(map[string]types.SQLTableColumn)
 
 	// log table
-	logCol["id"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameId,
+	logCol[types.SQLColumnLabelId] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelId,
 		Type:    types.SQLColumnTypeSerial,
 		Primary: true,
 		Order:   1,
 	}
 
-	logCol["timestamp"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameTimeStamp,
+	logCol[types.SQLColumnLabelTimeStamp] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelTimeStamp,
 		Type:    types.SQLColumnTypeTimeStamp,
 		Primary: false,
 		Order:   2,
 	}
 
-	logCol["tableName"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameTableName,
+	logCol[types.SQLColumnLabelTableName] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelTableName,
 		Type:    types.SQLColumnTypeVarchar,
 		Length:  100,
 		Primary: false,
 		Order:   3,
 	}
 
-	logCol["eventName"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameEventName,
+	logCol[types.EventNameLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelEventName,
 		Type:    types.SQLColumnTypeVarchar,
 		Length:  100,
 		Primary: false,
 		Order:   4,
 	}
 
-	logCol["rowCount"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameRowCount,
+	logCol[types.SQLColumnLabelRowCount] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelRowCount,
 		Type:    types.SQLColumnTypeInt,
 		Primary: false,
 		Order:   5,
 	}
 
-	logCol["eventFilter"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameEventFilter,
+	logCol[types.SQLColumnLabelEventFilter] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelEventFilter,
 		Type:    types.SQLColumnTypeVarchar,
 		Length:  100,
 		Primary: false,
 		Order:   6,
 	}
 
-	logCol["height"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameHeight,
+	logCol[types.BlockHeightLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelHeight,
 		Type:    types.SQLColumnTypeVarchar,
 		Length:  100,
 		Primary: false,
@@ -89,48 +89,48 @@ func (db *SQLDB) getSysTablesDefinition() types.EventTables {
 	}
 
 	// dictionary table
-	dicCol["tableName"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameTableName,
+	dicCol[types.SQLColumnLabelTableName] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelTableName,
 		Type:    types.SQLColumnTypeVarchar,
 		Length:  100,
 		Primary: true,
 		Order:   1,
 	}
 
-	dicCol["columnName"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameColumnName,
+	dicCol[types.SQLColumnLabelColumnName] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelColumnName,
 		Type:    types.SQLColumnTypeVarchar,
 		Length:  100,
 		Primary: true,
 		Order:   2,
 	}
 
-	dicCol["columnType"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameColumnType,
+	dicCol[types.SQLColumnLabelColumnType] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelColumnType,
 		Type:    types.SQLColumnTypeInt,
 		Length:  0,
 		Primary: false,
 		Order:   3,
 	}
 
-	dicCol["columnLenght"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameColumnLength,
+	dicCol[types.SQLColumnLabelColumnLength] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelColumnLength,
 		Type:    types.SQLColumnTypeInt,
 		Length:  0,
 		Primary: false,
 		Order:   4,
 	}
 
-	dicCol["columnPrimaryKey"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNamePrimaryKey,
+	dicCol[types.SQLColumnLabelPrimaryKey] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelPrimaryKey,
 		Type:    types.SQLColumnTypeInt,
 		Length:  0,
 		Primary: false,
 		Order:   5,
 	}
 
-	dicCol["columnOrder"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameColumnOrder,
+	dicCol[types.SQLColumnLabelColumnOrder] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelColumnOrder,
 		Type:    types.SQLColumnTypeInt,
 		Length:  0,
 		Primary: false,
@@ -345,14 +345,14 @@ func (db *SQLDB) createTable(table types.SQLTable) error {
 }
 
 // getBlockTables return all SQL tables that have been involved
-// in a given batch transaction for a specific block & events filter
-func (db *SQLDB) getBlockTables(eventFilter, block string) (types.EventTables, error) {
+// in a given batch transaction for a specific block
+func (db *SQLDB) getBlockTables(block string) (types.EventTables, error) {
 	tables := make(types.EventTables)
 
 	query := clean(db.DBAdapter.SelectLogQuery())
 	db.Log.Debug("msg", "QUERY LOG", "query", query, "value", block)
 
-	rows, err := db.DB.Query(query, eventFilter, block)
+	rows, err := db.DB.Query(query, block)
 	if err != nil {
 		db.Log.Debug("msg", "Error querying log", "err", err)
 		return tables, err

--- a/vent/sqlsol/block_data_test.go
+++ b/vent/sqlsol/block_data_test.go
@@ -30,18 +30,18 @@ func TestGetBlockID(t *testing.T) {
 
 func TestSetRow(t *testing.T) {
 	t.Run("successfully sets a new data row", func(t *testing.T) {
-		row := make(types.EventDataRow)
-		row["c1"] = "v1"
-		row["c2"] = "v2"
+		values := make(map[string]interface{})
+		values["c1"] = "v1"
+		values["c2"] = "v2"
 
 		blockData := sqlsol.NewBlockData()
-		blockData.AddRow("TEST_TABLE", row)
+		blockData.AddRow("TEST_TABLE", types.EventDataRow{Action: types.ActionUpsert, RowData: values})
 
 		rows, err := blockData.GetRows("TEST_TABLE")
 		require.NoError(t, err)
 		require.Equal(t, 1, len(rows))
-		require.Equal(t, "v1", rows[0]["c1"])
-		require.Equal(t, "v2", rows[0]["c2"])
+		require.Equal(t, "v1", rows[0].RowData["c1"])
+		require.Equal(t, "v2", rows[0].RowData["c2"])
 	})
 }
 
@@ -55,12 +55,12 @@ func TestGetBlockData(t *testing.T) {
 
 func TestPendingRows(t *testing.T) {
 	t.Run("successfully returns true if a given block has pending rows to upsert", func(t *testing.T) {
-		row := make(types.EventDataRow)
-		row["c1"] = "v1"
-		row["c2"] = "v2"
+		values := make(map[string]interface{})
+		values["c1"] = "v1"
+		values["c2"] = "v2"
 
 		blockData := sqlsol.NewBlockData()
-		blockData.AddRow("TEST_TABLE", row)
+		blockData.AddRow("TEST_TABLE", types.EventDataRow{Action: types.ActionUpsert, RowData: values})
 		blockData.SetBlockID("99")
 
 		hasRows := blockData.PendingRows("99")
@@ -69,12 +69,12 @@ func TestPendingRows(t *testing.T) {
 	})
 
 	t.Run("successfully returns false if a given block does not have pending rows to upsert", func(t *testing.T) {
-		row := make(types.EventDataRow)
-		row["c1"] = "v1"
-		row["c2"] = "v2"
+		values := make(map[string]interface{})
+		values["c1"] = "v1"
+		values["c2"] = "v2"
 
 		blockData := sqlsol.NewBlockData()
-		blockData.AddRow("TEST_TABLE", row)
+		blockData.AddRow("TEST_TABLE", types.EventDataRow{Action: types.ActionUpsert, RowData: values})
 		blockData.SetBlockID("99")
 
 		hasRows := blockData.PendingRows("88")

--- a/vent/sqlsol/parser.go
+++ b/vent/sqlsol/parser.go
@@ -231,44 +231,36 @@ func getSQLType(evmSignature string, isArray bool, bytesToString bool) (types.SQ
 func getGlobalColumns() map[string]types.SQLTableColumn {
 	globalColumns := make(map[string]types.SQLTableColumn)
 
-	globalColumns["height"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameHeight,
+	globalColumns[types.BlockHeightLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelHeight,
 		Type:    types.SQLColumnTypeVarchar,
 		Length:  100,
 		Primary: false,
 		Order:   1,
 	}
 
-	globalColumns["txHash"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameTxHash,
+	globalColumns[types.TxTxHashLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelTxHash,
 		Type:    types.SQLColumnTypeVarchar,
 		Length:  40,
 		Primary: false,
 		Order:   2,
 	}
 
-	globalColumns["index"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameIndex,
-		Type:    types.SQLColumnTypeNumeric,
-		Length:  0,
+	globalColumns[types.EventTypeLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelEventType,
+		Type:    types.SQLColumnTypeVarchar,
+		Length:  100,
 		Primary: false,
 		Order:   3,
 	}
 
-	globalColumns["eventType"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameEventType,
+	globalColumns[types.EventNameLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelEventName,
 		Type:    types.SQLColumnTypeVarchar,
 		Length:  100,
 		Primary: false,
 		Order:   4,
-	}
-
-	globalColumns["eventName"] = types.SQLTableColumn{
-		Name:    types.SQLColumnNameEventName,
-		Type:    types.SQLColumnTypeVarchar,
-		Length:  100,
-		Primary: false,
-		Order:   5,
 	}
 
 	return globalColumns

--- a/vent/sqlsol/parser_test.go
+++ b/vent/sqlsol/parser_test.go
@@ -47,19 +47,19 @@ func TestNewParser(t *testing.T) {
 		require.Equal(t, types.SQLColumnTypeVarchar, col.Type)
 		require.Equal(t, "address", col.Name)
 
-		col, err = tableStruct.GetColumn("UserAccounts", "index")
-		require.NoError(t, err)
-		require.Equal(t, false, col.Primary)
-		require.Equal(t, types.SQLColumnTypeNumeric, col.Type)
-		require.Equal(t, "_index", col.Name)
-		require.Equal(t, 3, col.Order)
-
-		col, err = tableStruct.GetColumn("UserAccounts", "height")
+		col, err = tableStruct.GetColumn("UserAccounts", "txHash")
 		require.NoError(t, err)
 		require.Equal(t, false, col.Primary)
 		require.Equal(t, types.SQLColumnTypeVarchar, col.Type)
-		require.Equal(t, "_height", col.Name)
-		require.Equal(t, 1, col.Order)
+		require.Equal(t, "_txhash", col.Name)
+		require.Equal(t, 2, col.Order)
+
+		col, err = tableStruct.GetColumn("UserAccounts", "eventName")
+		require.NoError(t, err)
+		require.Equal(t, false, col.Primary)
+		require.Equal(t, types.SQLColumnTypeVarchar, col.Type)
+		require.Equal(t, "_eventname", col.Name)
+		require.Equal(t, 4, col.Order)
 	})
 
 	t.Run("returns an error if the event type of a given column is unknown", func(t *testing.T) {

--- a/vent/sqlsol/spec_loader.go
+++ b/vent/sqlsol/spec_loader.go
@@ -1,9 +1,12 @@
 package sqlsol
 
-import "github.com/pkg/errors"
+import (
+	"github.com/monax/bosmarmot/vent/types"
+	"github.com/pkg/errors"
+)
 
 // SpecLoader loads spec files and parses them
-func SpecLoader(specDir, specFile string) (*Parser, error) {
+func SpecLoader(specDir, specFile string, createBlkTxTables bool) (*Parser, error) {
 
 	var parser *Parser
 	var err error
@@ -28,5 +31,126 @@ func SpecLoader(specDir, specFile string) (*Parser, error) {
 		}
 	}
 
+	if createBlkTxTables {
+		// add block & tx to tables definition
+		blkTxTables := getBlockTxTablesDefinition()
+
+		for k, v := range blkTxTables {
+			parser.Tables[k] = v
+		}
+
+	}
+
 	return parser, nil
+}
+
+// getBlockTxTablesDefinition returns block & transaction structures
+func getBlockTxTablesDefinition() types.EventTables {
+	tables := make(types.EventTables)
+	blockCol := make(map[string]types.SQLTableColumn)
+	txCol := make(map[string]types.SQLTableColumn)
+
+	// block table
+	blockCol[types.BlockHeightLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelHeight,
+		Type:    types.SQLColumnTypeVarchar,
+		Length:  100,
+		Primary: true,
+		Order:   1,
+	}
+
+	blockCol[types.BlockHeaderLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelBlockHeader,
+		Type:    types.SQLColumnTypeJSON,
+		Primary: false,
+		Order:   2,
+	}
+
+	blockCol[types.BlockTxExecLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelTxExec,
+		Type:    types.SQLColumnTypeJSON,
+		Primary: false,
+		Order:   3,
+	}
+
+	// transaction table
+	txCol[types.BlockHeightLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelHeight,
+		Type:    types.SQLColumnTypeVarchar,
+		Length:  100,
+		Primary: true,
+		Order:   1,
+	}
+
+	txCol[types.TxTxHashLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelTxHash,
+		Type:    types.SQLColumnTypeVarchar,
+		Length:  40,
+		Primary: true,
+		Order:   2,
+	}
+
+	txCol[types.TxIndexLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelIndex,
+		Type:    types.SQLColumnTypeNumeric,
+		Length:  0,
+		Primary: false,
+		Order:   3,
+	}
+
+	txCol[types.TxTxTypeLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelTxType,
+		Type:    types.SQLColumnTypeVarchar,
+		Length:  100,
+		Primary: false,
+		Order:   4,
+	}
+
+	txCol[types.TxEnvelopeLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelEnvelope,
+		Type:    types.SQLColumnTypeJSON,
+		Primary: false,
+		Order:   5,
+	}
+
+	txCol[types.TxEventsLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelEvents,
+		Type:    types.SQLColumnTypeJSON,
+		Primary: false,
+		Order:   6,
+	}
+
+	txCol[types.TxResultLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelResult,
+		Type:    types.SQLColumnTypeJSON,
+		Primary: false,
+		Order:   7,
+	}
+
+	txCol[types.TxReceiptLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelReceipt,
+		Type:    types.SQLColumnTypeJSON,
+		Primary: false,
+		Order:   8,
+	}
+
+	txCol[types.TxExceptionLabel] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelException,
+		Type:    types.SQLColumnTypeJSON,
+		Primary: false,
+		Order:   9,
+	}
+
+	// add tables
+	tables[types.SQLBlockTableName] = types.SQLTable{
+		Name:    types.SQLBlockTableName,
+		Columns: blockCol,
+	}
+
+	tables[types.SQLTxTableName] = types.SQLTable{
+		Name:    types.SQLTxTableName,
+		Columns: txCol,
+	}
+
+	return tables
 }

--- a/vent/sqlsol/spec_loader_test.go
+++ b/vent/sqlsol/spec_loader_test.go
@@ -1,0 +1,29 @@
+package sqlsol_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/monax/bosmarmot/vent/sqlsol"
+	"github.com/monax/bosmarmot/vent/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpecLoader(t *testing.T) {
+
+	specFile := os.Getenv("GOPATH") + "/src/github.com/monax/bosmarmot/vent/test/sqlsol_example.json"
+	dBBlockTx := true
+
+	t.Run("successfully add block and transaction tables to event structures", func(t *testing.T) {
+
+		parser, err := sqlsol.SpecLoader(specFile, "", dBBlockTx)
+
+		require.NoError(t, err)
+		require.Equal(t, 4, len(parser.Tables))
+		require.Equal(t, types.SQLBlockTableName, parser.Tables[types.SQLBlockTableName].Name)
+		require.Equal(t, strings.ToLower("_height"), parser.Tables[types.SQLBlockTableName].Columns["height"].Name)
+		require.Equal(t, types.SQLTxTableName, parser.Tables[types.SQLTxTableName].Name)
+		require.Equal(t, strings.ToLower("_txhash"), parser.Tables[types.SQLTxTableName].Columns["txHash"].Name)
+	})
+}

--- a/vent/test/sqlsol.go
+++ b/vent/test/sqlsol.go
@@ -12,6 +12,7 @@ func GoodJSONConfFile(t *testing.T) string {
 		{
 			"TableName" : "UserAccounts",
 			"Filter" : "LOG0 = 'UserAccounts'",
+			"DeleteFilter": "CRUD_ACTION = 'delete'",
 			"Columns"  : {
 				"userAddress" : {"name" : "address", "type": "address", "primary" : true},
 				"userName": {"name" : "username", "type": "string", "primary" : false},
@@ -22,6 +23,7 @@ func GoodJSONConfFile(t *testing.T) string {
 		{
 		"TableName" : "TEST_TABLE",
 		"Filter" : "Log1Text = 'EVENT_TEST'",
+		"DeleteFilter": "CRUD_ACTION = 'delete'",
 		"Columns"  : {
 			"key"		: {"name" : "Index",    "type": "uint256", "primary" : true},
 			"blocknum"  : {"name" : "Block",    "type": "uint256", "primary" : false},
@@ -59,6 +61,7 @@ func UnknownTypeJSONConfFile(t *testing.T) string {
 		{
 			"TableName" : "UserAccounts",
 			"Filter" : "LOG0 = 'UserAccounts'",
+			"DeleteFilter": "CRUD_ACTION = 'delete'",
 			"Event"  : {
 				"anonymous": false,
 				"inputs": [{
@@ -85,6 +88,7 @@ func UnknownTypeJSONConfFile(t *testing.T) string {
 		{
 			"TableName" : "EventTest",
 			"Filter" : "LOG0 = 'EventTest'",
+			"DeleteFilter": "CRUD_ACTION = 'delete'",
 			"Event"  : {
 				"anonymous": false,
 				"inputs": [{
@@ -153,28 +157,7 @@ func DuplicatedColNameJSONConfFile(t *testing.T) string {
 		{
 			"TableName" : "DUPLICATED_COLUMN",
 			"Filter" : "LOG0 = 'UserAccounts'",
-			"Event"  : {
-				"anonymous": false,
-				"inputs": [{
-					"indexed": false,
-					"name": "userName",
-					"type": "string"
-				}, {
-					"indexed": false,
-					"name": "userAddress",
-					"type": "address"
-				}, {
-					"indexed": false,
-					"name": "userBool",
-					"type": "bool"
-				}, {
-					"indexed": false,
-					"name": "userId",
-					"type": "uint"
-				}],
-				"name": "UpdateUserAccount",
-				"type": "event"
-			},
+			"DeleteFilter": "CRUD_ACTION = 'delete'",
 			"Columns"  : {
 				"userAddress" : {"name" : "address", "primary" : true},
 				"userName": {"name" : "duplicated", "primary" : false},

--- a/vent/test/sqlsol_example.json
+++ b/vent/test/sqlsol_example.json
@@ -2,6 +2,7 @@
   {
     "TableName" : "EventTest",
     "Filter" : "EventType = 'LogEvent'",
+    "DeleteFilter": "CRUD_ACTION = 'delete'",
     "Columns"  : {
       "key" : {"name" : "testkey", "type": "bytes32", "primary" : true},
       "name" : {"name" : "testname", "type": "bytes32", "primary" : true, "bytesToString": true},

--- a/vent/types/event_data.go
+++ b/vent/types/event_data.go
@@ -1,5 +1,14 @@
 package types
 
+// CRUDAction generic type
+type CRUDAction int
+
+const (
+	ActionDelete CRUDAction = iota
+	ActionUpsert
+	ActionRead
+)
+
 // EventData contains data for each block of events
 // already mapped to SQL columns & tables
 // Tables map key is the table name
@@ -13,4 +22,8 @@ type EventDataTable []EventDataRow
 
 // EventDataRow contains each SQL column name and a corresponding value to upsert
 // map key is the column name and map value is the given column value
-type EventDataRow map[string]interface{}
+// if Action == 'delete' then the row has to be deleted
+type EventDataRow struct {
+	Action  CRUDAction
+	RowData map[string]interface{}
+}

--- a/vent/types/event_definition.go
+++ b/vent/types/event_definition.go
@@ -10,10 +10,11 @@ type EventSpec []EventDefinition
 
 // EventDefinition struct (table name where to persist filtered events and it structure)
 type EventDefinition struct {
-	TableName string                 `json:"TableName"`
-	Filter    string                 `json:"Filter"`
-	Columns   map[string]EventColumn `json:"Columns"`
-	query     query.Query
+	TableName    string                 `json:"TableName"`
+	Filter       string                 `json:"Filter"`
+	DeleteFilter string                 `json:"DeleteFilter"`
+	Columns      map[string]EventColumn `json:"Columns"`
+	query        query.Query
 }
 
 // Validate checks the structure of an EventDefinition

--- a/vent/types/sql_column_type.go
+++ b/vent/types/sql_column_type.go
@@ -13,6 +13,7 @@ const (
 	SQLColumnTypeVarchar
 	SQLColumnTypeTimeStamp
 	SQLColumnTypeNumeric
+	SQLColumnTypeJSON
 )
 
 // IsNumeric determines if an sqlColumnType is numeric

--- a/vent/types/sql_table.go
+++ b/vent/types/sql_table.go
@@ -36,29 +36,61 @@ type UpsertColumn struct {
 // SQL log & dictionary tables
 const SQLLogTableName = "_vent_log"
 const SQLDictionaryTableName = "_vent_dictionary"
+const SQLBlockTableName = "_vent_block"
+const SQLTxTableName = "_vent_tx"
 
-// defined fixed sql column names in log table
+// fixed sql column names in tables
 const (
 	// log
-	SQLColumnNameId          = "_id"
-	SQLColumnNameTimeStamp   = "_timestamp"
-	SQLColumnNameEventName   = "_eventname"
-	SQLColumnNameRowCount    = "_rowcount"
-	SQLColumnNameEventFilter = "_eventfilter"
-	SQLColumnNameHeight      = "_height"
+	SQLColumnLabelId          = "_id"
+	SQLColumnLabelTimeStamp   = "_timestamp"
+	SQLColumnLabelEventName   = "_eventname"
+	SQLColumnLabelRowCount    = "_rowcount"
+	SQLColumnLabelEventFilter = "_eventfilter"
+	SQLColumnLabelHeight      = "_height"
 
 	// common
-	SQLColumnNameTableName = "_tablename"
+	SQLColumnLabelTableName = "_tablename"
 
 	// dictionary
-	SQLColumnNameColumnName   = "_columnname"
-	SQLColumnNameColumnType   = "_columntype"
-	SQLColumnNameColumnLength = "_columnlength"
-	SQLColumnNamePrimaryKey   = "_primarykey"
-	SQLColumnNameColumnOrder  = "_columnorder"
+	SQLColumnLabelColumnName   = "_columnname"
+	SQLColumnLabelColumnType   = "_columntype"
+	SQLColumnLabelColumnLength = "_columnlength"
+	SQLColumnLabelPrimaryKey   = "_primarykey"
+	SQLColumnLabelColumnOrder  = "_columnorder"
 
-	// auxiliar (not in DB)
-	SQLColumnNameIndex     = "_index"
-	SQLColumnNameTxHash    = "_txhash"
-	SQLColumnNameEventType = "_eventtype"
+	// context
+	SQLColumnLabelIndex       = "_index"
+	SQLColumnLabelTxHash      = "_txhash"
+	SQLColumnLabelEventType   = "_eventtype"
+	SQLColumnLabelBlockHeader = "_blockheader"
+	SQLColumnLabelTxType      = "_txtype"
+	SQLColumnLabelTxExec      = "_txexecutions"
+	SQLColumnLabelEnvelope    = "_envelope"
+	SQLColumnLabelEvents      = "_events"
+	SQLColumnLabelResult      = "_result"
+	SQLColumnLabelReceipt     = "_receipt"
+	SQLColumnLabelException   = "_exception"
+)
+
+// labels for column mapping
+const (
+	// event related
+	EventNameLabel = "eventName"
+	EventTypeLabel = "eventType"
+
+	// block related
+	BlockHeightLabel = "height"
+	BlockHeaderLabel = "blockHeader"
+	BlockTxExecLabel = "txExecutions"
+
+	// transaction related
+	TxTxTypeLabel    = "txType"
+	TxTxHashLabel    = "txHash"
+	TxIndexLabel     = "index"
+	TxEnvelopeLabel  = "envelope"
+	TxEventsLabel    = "events"
+	TxResultLabel    = "result"
+	TxReceiptLabel   = "receipt"
+	TxExceptionLabel = "exception"
 )


### PR DESCRIPTION
new boolean config flag `db-block` to create block and tx tables and store related info, now events can be deleted based on their tables pk if proper `DeleteFilter` is defined in spec and provided when emitting events.