### PR TITLE
Use cascading table drop for Vent

### DIFF
--- a/vent/sqldb/adapters/postgres_adapter.go
+++ b/vent/sqldb/adapters/postgres_adapter.go
@@ -469,6 +469,8 @@ func (adapter *PostgresAdapter) CleanDBQueries() types.SQLCleanDBQuery {
 }
 
 func (adapter *PostgresAdapter) DropTableQuery(tableName string) string {
-	//drop tables
-	return fmt.Sprintf(`DROP TABLE %s.%s;`, adapter.Schema, tableName)
+	// We cascade here to drop any associated views and triggers. We work under the assumption that vent
+	// owns its database and any users need to be able to recreate objects that depend on vent tables in the event of
+	// table drops
+	return fmt.Sprintf(`DROP TABLE %s.%s CASCADE;`, adapter.Schema, tableName)
 }

--- a/vent/sqldb/adapters/sqlite_adapter.go
+++ b/vent/sqldb/adapters/sqlite_adapter.go
@@ -458,6 +458,6 @@ func (adapter *SQLiteAdapter) CleanDBQueries() types.SQLCleanDBQuery {
 }
 
 func (adapter *SQLiteAdapter) DropTableQuery(tableName string) string {
-	//drop tables
+	// SQLite does not support DROP TABLE CASCADE so this will fail if there are dependent objects
 	return fmt.Sprintf(`DROP TABLE %s;`, tableName)
 }

--- a/vent/sqldb/sqldb.go
+++ b/vent/sqldb/sqldb.go
@@ -195,17 +195,10 @@ func (db *SQLDB) CleanTables(chainID, burrowVersion string) error {
 			db.Log.Info("msg", "Error deleting log", "err", err, "query", query)
 			return err
 		}
-
-		// Commit
-		if err = tx.Commit(); err != nil {
-			db.Log.Info("msg", "Error commiting transaction", "err", err)
-			return err
-		}
-
 		// Drop database tables
 		for _, tableName = range tables {
 			query = clean(db.DBAdapter.DropTableQuery(tableName))
-			if _, err = db.DB.Exec(query); err != nil {
+			if _, err = tx.Exec(query); err != nil {
 				// if error == table does not exists, continue
 				if !db.DBAdapter.ErrorEquals(err, types.SQLErrorTypeUndefinedTable) {
 					db.Log.Info("msg", "error dropping tables", "err", err, "value", tableName, "query", query)
@@ -213,6 +206,13 @@ func (db *SQLDB) CleanTables(chainID, burrowVersion string) error {
 				}
 			}
 		}
+
+		// Commit
+		if err = tx.Commit(); err != nil {
+			db.Log.Info("msg", "Error commiting transaction", "err", err)
+			return err
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
This allows for Vent's ChainID table dropping to work as
intended.
Also make CleanDB run entirely in transaction

Signed-off-by: Silas Davis <silas@monax.io>