### PR TITLE
Consumer events filtered server side

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -652,6 +652,7 @@
     "github.com/go-ozzo/ozzo-validation",
     "github.com/hyperledger/burrow/core",
     "github.com/hyperledger/burrow/crypto",
+    "github.com/hyperledger/burrow/event",
     "github.com/hyperledger/burrow/event/query",
     "github.com/hyperledger/burrow/execution/evm/abi",
     "github.com/hyperledger/burrow/execution/exec",

--- a/vent/cmd/vent.go
+++ b/vent/cmd/vent.go
@@ -48,6 +48,9 @@ func runVentCmd(cmd *cobra.Command, args []string) {
 	consumer := service.NewConsumer(cfg, log, make(chan types.EventData))
 	server := service.NewServer(cfg, log, consumer)
 
+	if cfg.DBBlockTx {
+		log.Warn("msg", "Vent started with DBBlockTx option - but this behaviour is suppressed in this hotfix version of Vent")
+	}
 	parser, err := sqlsol.SpecLoader(cfg.SpecDir, cfg.SpecFile, cfg.DBBlockTx)
 	if err != nil {
 		log.Error("err", err)

--- a/vent/service/consumer_test.go
+++ b/vent/service/consumer_test.go
@@ -57,11 +57,12 @@ func TestConsumer(t *testing.T) {
 	// test data stored in database for two different block ids
 	eventName := "EventTest"
 
+	expectedTables := 1
 	blockID := "2"
 	eventData, err := db.GetBlock(blockID)
 	require.NoError(t, err)
 	require.Equal(t, "2", eventData.Block)
-	require.Equal(t, 3, len(eventData.Tables))
+	require.Equal(t, expectedTables, len(eventData.Tables))
 
 	tblData := eventData.Tables[strings.ToLower(eventName)]
 	require.Equal(t, 1, len(tblData))
@@ -72,22 +73,12 @@ func TestConsumer(t *testing.T) {
 	eventData, err = db.GetBlock(blockID)
 	require.NoError(t, err)
 	require.Equal(t, "5", eventData.Block)
-	require.Equal(t, 3, len(eventData.Tables))
+	require.Equal(t, expectedTables, len(eventData.Tables))
 
 	tblData = eventData.Tables[strings.ToLower(eventName)]
 	require.Equal(t, 1, len(tblData))
 	require.Equal(t, "LogEvent", tblData[0].RowData["_eventtype"].(string))
 	require.Equal(t, "UpdateTestEvents", tblData[0].RowData["_eventname"].(string))
-
-	// block & tx raw data also persisted
-	if cfg.DBBlockTx {
-		tblData = eventData.Tables[types.SQLBlockTableName]
-		require.Equal(t, 1, len(tblData))
-
-		tblData = eventData.Tables[types.SQLTxTableName]
-		require.Equal(t, 1, len(tblData))
-		require.Equal(t, "B216CCD3919E82BE7206DFDFF08D3625E1F9E6B9", tblData[0].RowData["_txhash"].(string))
-	}
 
 	//Restore
 	ti := time.Now().Local().AddDate(10, 0, 0)


### PR DESCRIPTION
This PR switches this legacy version of Vent into a mode that filters for EVM `LogEvent` only server side to mitigate the potential for blocks that may be over the 4 MiB GRPC message size limit.

See the new Vent in Burrow for a streaming model of execution events that avoids this while still allowing consumption of blocks and events.